### PR TITLE
Fixed naming function to only check for letters

### DIFF
--- a/lib/utils/naming.js
+++ b/lib/utils/naming.js
@@ -2,7 +2,9 @@ export function camelCaseToPipeCase(str) {
   let result = ''
   for (let i = 0; i < str.length; i++) {
     const char = str.charAt(i)
-    if (char === char.toUpperCase()) {
+
+    // Make sure the character is actually a capital letter.
+    if (char === char.toUpperCase() && char !== char.toLowerCase()) {
       result += '-'
     }
     result += char.toLowerCase()


### PR DESCRIPTION
The function previously incorrectly recognized spaces and numbers as capital letters.