### PR TITLE
Removed default padding from GridList

### DIFF
--- a/lib/components/GridList/GridListItem.js
+++ b/lib/components/GridList/GridListItem.js
@@ -46,7 +46,9 @@ class GridListItem extends TrackedDimensionPureComponent {
 
     return (
       <Division gridListWidth={gridListWidth}>
-        <Box width="100%">{children}</Box>
+        <Box width="100%" padding="0">
+          {children}
+        </Box>
       </Division>
     )
   }

--- a/lib/components/GridList/stories.js
+++ b/lib/components/GridList/stories.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import {storiesOf} from '@storybook/react'
 import {doc} from 'storybook-readme'
+import Box from '../Box'
 import {GridList, GridListItem} from './index'
 import Documentation from './README.md'
 
@@ -21,5 +22,50 @@ storiesOf('GridList', module)
       </GridListItem>
       <GridListItem>Item 7</GridListItem>
       <GridListItem>Item 8</GridListItem>
+    </GridList>
+  ))
+  .add('with custom children grid list', () => (
+    <GridList>
+      <GridListItem>
+        <Box background="pink" width="100%">
+          Item 1
+        </Box>
+      </GridListItem>
+      <GridListItem>
+        <Box background="pink" width="100%">
+          This item is much longer in width. This item is much longer in width.
+          This item is much longer in width. This item is much longer in width.
+        </Box>
+      </GridListItem>
+      <GridListItem>
+        <Box background="pink" width="100%">
+          Item 3
+        </Box>
+      </GridListItem>
+      <GridListItem>
+        <Box background="pink" width="100%">
+          Item 4
+        </Box>
+      </GridListItem>
+      <GridListItem>
+        <Box background="pink" width="100%">
+          Item 5
+        </Box>
+      </GridListItem>
+      <GridListItem>
+        <Box background="pink" width="100%">
+          This item is much longer in width. This item is much longer in width.
+        </Box>
+      </GridListItem>
+      <GridListItem>
+        <Box background="pink" width="100%">
+          Item 7
+        </Box>
+      </GridListItem>
+      <GridListItem>
+        <Box background="pink" width="100%">
+          Item 8
+        </Box>
+      </GridListItem>
     </GridList>
   ))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remiges",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "main": "dist/lib/index.js",
   "repository": "git@github.com:angusburg/remiges.git",
   "author": "angus <angushtlam@gmail.com>",


### PR DESCRIPTION
GridList by default added padding for children inside which might not . This removes the inner padding.

To add padding for children, use the Box component to add it manually.